### PR TITLE
opbible: improve Makefile, respect user's CXX, C(P|XX)FLAGS, and LDFLAGS

### DIFF
--- a/txs-gen/Makefile
+++ b/txs-gen/Makefile
@@ -5,35 +5,19 @@
 
 ## definitions
 
-CXX = g++
-LD = g++
-LIBS = -lsword
-LDFLAGS = $(LIBS)
-CXXFLAGS = -I/usr/include/sword
+LDLIBS = $(shell pkg-config --libs sword)
 
-target = mod2tex
-objects = mod2tex.o
+CXXFLAGS += $(shell pkg-config --cflags sword)
 
 ## static rules
 
 .PHONY : all
 
-all : $(target)
-
-$(target) : $(objects)
-	$(LD) -o $@ $< $(LDFLAGS)
-
-$(objects) : %.o: %.cpp
-	$(CXX) -c $(CXXFLAGS) -o $@ $<
+all : mod2tex
 
 .PHONY : clean
 
 clean :
-	-rm -f *~ $(objects) $(target)
-
-## pattern rules
-
-%.o : %.cpp
-	$(CXX) -c $(CFLAGS) $(CXXFLAGS) -o $@ $<
+	-rm -f *~ mod2tex
 
 ### Makefile ends here


### PR DESCRIPTION
Make the Makefile respect the user's CXX, C(P|XX)FLAGS, and LDFLAGS by either using GNU Make's implicit rules or by appending instead of overriding the CXXFLAGS variable. This also has the nice advantage that the Makefile becomes more idiomatic and shorter.

The Makefile not respecting user variables was initially report by Gentoo's CI and the following two downstream bugs:
- https://bugs.gentoo.org/925710
- https://bugs.gentoo.org/925711